### PR TITLE
Fix `npx bluesky-daily-mcp`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "/dist"
   ],
   "bin": {
-    "bluesky-daily-mcp": "dist/index.js"
+    "bluesky-daily-mcp": "./dist/cli.js"
   },
   "type": "module",
   "module": "./dist/index.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -42,7 +42,16 @@ export default [
     plugins,
     external,
   },
-  // Single d.ts file
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/cli.js',
+      format: 'esm',
+      banner: '#!/usr/bin/env node',
+    },
+    plugins,
+    external,
+  },
   {
     input: 'src/index.ts',
     output: {


### PR DESCRIPTION
- fix issue where `npm bluesky-daily-mcp` wasn't running.
- automatically generate CLI as a script via rollup
