### PR TITLE
Add author's handle. Describe fields in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,19 @@ For examples of how to use, please visit ["Building an MCP Server to Explore My 
 - sample prompts for analyzing posts
 - caches the posts for a given day
 
-Posts are retrieved via [`bsky-tldr`](https://www.npmjs.com/package/bsky-tldr) npm package which normalizes them into this format for easy consumption by LLM:
+Follows and Posts are retrieved via [`bsky-tldr`](https://www.npmjs.com/package/bsky-tldr) npm package which both (a) shaves down infomation to just the key fields, and (b) ensures posts are efficiently retrieved for only the day requested.
 
-```json
-[
-  {
-    "uri": "at://did:plc:kft6lu4trxowqmter2b6vg6z/app.bsky.feed.post/3lh4unyelgs2i",
-    "content": "There are some missing details in this report claiming to have leaked the system prompt - most notably they don't clarify if they got the system prompt for DeepSeek v3 or DeepSeek R1 (I'm interred in R1) lab.wallarm.com/jailbreaking...",
-    "createdAt": "2025-02-01T15:53:09.612Z",
-    "isRepost": false,
-    "links": ["https://lab.wallarm.com/jailbreaking-generative-ai/"]
-  }
-]
+In this MCP Server, we add more descriptive field names and combine author and post information together for easy consumption by the LLM:
+
+```typescript
+type StandalonePost = {
+  urlToOriginalPost: string;
+  authorIdentifier: string;
+  authorNameOrHandle: string;
+  content: string;
+  links: string[];
+  isRepost: boolean;
+};
 ```
 
 <img src="https://github.com/briangershon/bluesky-daily-mcp/blob/main/screenshots/visual-summary-of-bluesky-posts.jpg?raw=true" width="600" height="600" alt="Visual Summary of Bluesky Posts" />
@@ -29,6 +30,8 @@ Posts are retrieved via [`bsky-tldr`](https://www.npmjs.com/package/bsky-tldr) n
 ## Limitations
 
 - This retrieves all posts from your follows for a given day. This will become large and subsequently you'll lose posts that are truncated by the MCP Client or the LLM's context window. Will need additional strategies to handle this.
+
+- You'll run into Bluesky API rate limits and/or timeouts if you try to retrieve posts from historic dates, say weeks or months ago. `bsky-tldr` package is smart enough to stop retrieving posts older than the day requested, but does need to retrieve all the newer ones on its way to the historic date.
 
 ## Installation
 

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -23,6 +23,11 @@ export const prompts: Record<string, Prompt> = {
     - Summarize key topics and include details so it is not generic
     - Explain which posts were part of each topic
     - urlToOriginalPost is a Bluesky post is in the format of "https://bsky.app/profile/did:plc:<DID>/post/<postId>". Do not modify, shorten, or split urlToOriginalPost links in any way. Treat the 'did:plc' component of links as an essential part of the URL that must be preserved intact. When sharing links, always verify that the full URL is visible and clickable. Links should always be on one line.
+    - authorIdentifier is the did of the author
+    - authorNameOrHandle is the author's handle
+    - content is the content of the post
+    - links is an array of URLs in the post
+    - isRepost is false if it is an original post or true if it is a re-post
     - Annotate each summary with urlToOriginalPost
     
     Most Interesting (prioritize posts that have content with URLs or software development):
@@ -39,6 +44,6 @@ export const prompts: Record<string, Prompt> = {
   [PROMPT_SUMMARIZE_AUTHORS_POSTS]: {
     description: "Summarize each author's posts and group by author",
     prompt:
-      "Group posts by Author and then summarize each author's posts. Show post count, and a summary of their posts. Include the most interesting posts and any notable themes or topics. Provide a markdown summary with links to the original posts. For authors, show link to their profile on Bluesky.",
+      "Group posts by Author and then summarize each author's posts. Show post count, and a summary of their posts. Include the most interesting posts and any notable themes or topics. Provide a markdown summary with links to the original posts. For authors, show their handle from 'authorNameOrHandle' and a link to their profile using 'authorIdentifier' on Bluesky.",
   },
 };

--- a/src/lib/resources.ts
+++ b/src/lib/resources.ts
@@ -13,10 +13,11 @@ type MCPResource = {
 // these attributes are named to be meaningful to the LLM model
 type StandalonePost = {
   urlToOriginalPost: string;
-  authorWhoPostedOrReposted: string;
+  authorIdentifier: string;
+  authorNameOrHandle: string;
   content: string;
   links: string[];
-  didAuthorRepost: boolean;
+  isRepost: boolean;
 };
 
 export const dailyPostsResourcesTemplateUri = 'blueskydaily://posts/{yyyymmdd}';
@@ -93,10 +94,11 @@ export async function retrievePosts(
     })) {
       posts.push({
         urlToOriginalPost: uriToUrl(post.uri) || '',
-        authorWhoPostedOrReposted: follow.did,
+        authorIdentifier: follow.did,
+        authorNameOrHandle: follow.handle,
         content: post.content,
         links: post.links,
-        didAuthorRepost: post.isRepost,
+        isRepost: post.isRepost,
       });
     }
 


### PR DESCRIPTION
- Add author's friendly handle name for nicer results when running the "Summarize each author's posts and group by author" prompt.
- Describe all incoming Follow and Post fields in the prompts, and in the README.
- Add warning in README about reaching Bluesky API rate limits when retrieving historic posts.